### PR TITLE
fix: use correct API endpoint for repo access token

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27587,7 +27587,7 @@ async function retrieveGithubAccessToken(fullRepo, apiKey) {
 
   console.log(`Getting Github access token for`, { owner, repo });
 
-  const url = `${BASE_URL}/github-access-token`;
+  const url = `${BASE_URL}/repo-access-token`;
   const res = await fetch(url, {
     method: 'POST',
     body: JSON.stringify({

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function retrieveGithubAccessToken(fullRepo, apiKey) {
 
   console.log(`Getting Github access token for`, { owner, repo });
 
-  const url = `${BASE_URL}/github-access-token`;
+  const url = `${BASE_URL}/repo-access-token`;
   const res = await fetch(url, {
     method: 'POST',
     body: JSON.stringify({


### PR DESCRIPTION
## Summary

- The Stainless API endpoint was renamed from `/api/github-access-token` to `/api/repo-access-token`, causing this action to receive 404 responses for all callers
- This is breaking CI for every SDK repo that uses this action (CLI, Terraform, SQL SDKs)

## Test plan

- [ ] Verify a repo using this action (e.g. `stainless-sdks/anthropic-cli`) passes the setup-go step after updating to this version

🤖 Generated with [Claude Code](https://claude.com/claude-code)